### PR TITLE
Update configuration.rb -> set default charset encoding

### DIFF
--- a/lib/skuby/configuration.rb
+++ b/lib/skuby/configuration.rb
@@ -15,6 +15,7 @@ module Skuby
 
     def initialize
       @method = 'send_sms_classic'
+      @charset = 'UTF-8'
     end
 
     def to_hash


### PR DESCRIPTION
added line 18: to set default charset encoding to UTF-8, to solve the issue that arise when a SMS text contain not-ASCII chars, by example with this SMS text: ("la realtà è giù di lì!")
