### PR TITLE
Disabled ssl verification for expired certificates on skebby gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,88 @@
+# Created by https://www.gitignore.io/api/ruby,rubymine
+
+### Ruby ###
 *.gem
 *.rbc
-.bundle
-.config
-.yardoc
-.ruby-version
-.ruby-gemset
-Gemfile.lock
-InstalledFiles
-_yardoc
-coverage
-doc/
-lib/bundler/man
-pkg
-rdoc
-spec/reports
-test/tmp
-test/version_tmp
-tmp
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalisation:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+
+### RubyMine ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    awesome_print (1.6.1)
     coveralls (0.8.3)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -28,7 +27,6 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
-    hashdiff (0.2.2)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     httparty (0.13.7)
@@ -48,19 +46,14 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
     safe_yaml (1.0.4)
     simplecov (0.10.0)
       docile (~> 1.1.0)
@@ -78,21 +71,19 @@ GEM
       unf_ext
     unf_ext (0.0.7.1)
     vcr (2.9.3)
-    webmock (1.22.1)
+    webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_print (~> 1.6.1)
   bundler (~> 1.3)
-  coveralls
-  mocha
+  coveralls (~> 0.8.2)
+  mocha (~> 1.1.0)
   rake
-  rspec
+  rspec (~> 2.99.0)
   skuby!
-  vcr
-  webmock
+  vcr (~> 2.9.3)
+  webmock (~> 1.21.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,98 @@
+PATH
+  remote: .
+  specs:
+    skuby (0.0.5)
+      activesupport
+      httparty (~> 0.13.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.4)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.8)
+    awesome_print (1.6.1)
+    coveralls (0.8.3)
+      json (~> 1.8)
+      rest-client (>= 1.6.8, < 2)
+      simplecov (~> 0.10.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
+    hashdiff (0.2.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    i18n (0.7.0)
+    json (1.8.3)
+    metaclass (0.0.4)
+    mime-types (2.6.2)
+    minitest (5.8.2)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_xml (0.5.5)
+    netrc (0.10.3)
+    rake (10.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    safe_yaml (1.0.4)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    tins (1.6.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+    vcr (2.9.3)
+    webmock (1.22.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  awesome_print (~> 1.6.1)
+  bundler (~> 1.3)
+  coveralls
+  mocha
+  rake
+  rspec
+  skuby!
+  vcr
+  webmock

--- a/lib/skuby/credit.rb
+++ b/lib/skuby/credit.rb
@@ -4,7 +4,7 @@ module Skuby
     base_uri 'https://gateway.skebby.it/api/send/smseasy/advanced/http.php'
 
     def self.balance
-      response = CGI.parse(post('', body: build_params))
+      response = CGI.parse(post('', body: build_params, verify: false))
       response["credit_left"].first.to_f if response["status"].first == "success"
     end
 
@@ -14,4 +14,3 @@ module Skuby
 
   end
 end
-

--- a/lib/skuby/gateway.rb
+++ b/lib/skuby/gateway.rb
@@ -5,7 +5,7 @@ module Skuby
 
     def self.send_sms(text = '', recipients = '')
       params = build_params(text, recipients)
-      SMSResponse.new(self.post('', body: params), text, recipients)
+      SMSResponse.new(self.post('', body: params, verify: false), text, recipients)
     end
 
     def self.build_params(text, recipients)
@@ -13,4 +13,3 @@ module Skuby
     end
   end
 end
-

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -4,29 +4,29 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'skuby/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "skuby"
+  spec.name          = 'skuby'
   spec.version       = Skuby::VERSION
-  spec.authors       = ["Fabrizio Monti", "Filippo Gangi Dino"]
-  spec.email         = ["fabrizio.monti@welaika.com", "filippo.gangidino@welaika.com"]
+  spec.authors       = ['Fabrizio Monti', 'Filippo Gangi Dino']
+  spec.email         = ['fabrizio.monti@welaika.com', 'filippo.gangidino@welaika.com']
   spec.description   = %q{A Ruby interface to Skebby}
   spec.summary       = %q{Allows you to send SMS through Skebby SMS Gateway}
-  spec.homepage      = "https://github.com/welaika/skuby"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/welaika/skuby'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "httparty"
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency 'httparty', '~> 0.13.5'
+  spec.add_runtime_dependency 'activesupport'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "pry-plus"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "mocha"
-  spec.add_development_dependency "webmock"
-  spec.add_development_dependency "vcr"
-  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'mocha'
+  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'awesome_print', '~> 1.6.1'
 end

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -23,10 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'awesome_print', '~> 1.6.1'
+  spec.add_development_dependency 'rspec', '~> 2.99.0'
+  spec.add_development_dependency 'mocha', '~> 1.1.0'
+  spec.add_development_dependency 'webmock', '~> 1.21.0'
+  spec.add_development_dependency 'vcr', '~> 2.9.3'
+  spec.add_development_dependency 'coveralls', '~> 0.8.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ Coveralls.wear!
 require 'webmock/rspec'
 require 'mocha/api'
 require 'vcr'
-require 'pry'
 
 require 'skuby'
 
@@ -24,4 +23,3 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   c.hook_into :webmock
 end
-


### PR DESCRIPTION
Sometimes requests to Skebby gateway fail due to problems related to their ssl certificates. I have disabled ssl verification on post requests.