### PR TITLE
Change the format to use multiple recipients

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---color
---format progress

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.3
   Include:
     - Rakefile
     - config.ru
@@ -22,6 +23,9 @@ Metrics/AbcSize:
 
 OutputSafety:
   Enabled: false
+
+FrozenStringLiteralComment:
+  Enabled: true
 
 Style/Documentation:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,34 @@
+AllCops:
+  Include:
+    - Rakefile
+    - config.ru
+    - lib/**/*.rake
+  Exclude:
+    - db/**/*
+    - vendor/**/*
+    - client/node_modules/**/*
+
+Rails:
+  Enabled: true
+
+Metrics/MethodLength:
+  Max: 20
+
+Metrics/ClassLength:
+  Max: 1500
+
+Metrics/AbcSize:
+  Max: 20
+
+OutputSafety:
+  Enabled: false
+
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'app/controllers/application_controller.rb'
+    - 'app/helpers/application_helper.rb'
+    - 'app/mailers/application_mailer.rb'
+    - 'app/models/application_record.rb'
+    - 'db/migrate/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - "1.9.3"
-  - "2.0.0"
+  - "2.3.1"
 
-script: "bundle exec rspec spec"
+script: "bundle exec rake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
 rvm:
-  - "2.3.1"
+  - 2.3.1
 
-script: "bundle exec rake"
+script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ gem 'minitest-reporters'
 gem 'vcr'
 
 gem 'coveralls', require: false
-gem 'rubocop'
+gem 'simplecov', require: false
+gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,13 @@ ruby '2.3.1'
 gem 'httparty'
 gem 'activesupport'
 gem 'rake'
-gem 'webmock'
-gem 'minitest'
-gem 'minitest-reporters'
-gem 'vcr'
 
-gem 'coveralls', require: false
-gem 'simplecov', require: false
-gem 'rubocop', require: false
+group :test do
+  gem 'webmock'
+  gem 'minitest'
+  gem 'minitest-reporters'
+  gem 'vcr'
+  gem 'coveralls', require: false
+  gem 'simplecov', require: false
+  gem 'rubocop', require: false
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem 'rake'
 gem 'webmock'
 gem 'minitest'
 gem 'vcr'
+
+gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem 'minitest'
 gem 'vcr'
 
 gem 'coveralls', require: false
+gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport'
 gem 'rake'
 gem 'webmock'
 gem 'minitest'
-gem 'minitest/reporters'
+gem 'minitest-reporters'
 gem 'vcr'
 
 gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.1'
+
 gem 'httparty'
 gem 'activesupport'
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in skuby.gemspec
-gemspec
+gem 'httparty'
+gem 'activesupport'
+gem 'rake'
+gem 'webmock'
+gem 'minitest'
+gem 'vcr'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'activesupport'
 gem 'rake'
 gem 'webmock'
 gem 'minitest'
+gem 'minitest/reporters'
 gem 'vcr'
 
 gem 'coveralls', require: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Skuby
 
-[![Build Status](https://travis-ci.org/welaika/skuby.png?branch=master)](https://travis-ci.org/welaika/skuby)
+<!-- [![Build Status](https://travis-ci.org/welaika/skuby.png?branch=master)](https://travis-ci.org/welaika/skuby)
 [![Coverage Status](https://coveralls.io/repos/welaika/skuby/badge.png)](https://coveralls.io/r/welaika/skuby)
 [![Code Climate](https://codeclimate.com/github/welaika/skuby.png)](https://codeclimate.com/github/welaika/skuby)
-[![Dependency Status](https://gemnasium.com/welaika/skuby.png)](https://gemnasium.com/welaika/skuby)
+[![Dependency Status](https://gemnasium.com/welaika/skuby.png)](https://gemnasium.com/welaika/skuby) -->
+
+NOTE: This is a fork of the original [Skuby](https://github.com/welaika/skuby) by Fabrizio Monti, Filippo Gangi Dino. This fork exists because I needed a specific behaviour from this gem. The main difference is in the recipient format.
 
 A Ruby interface for Skebby
 Allows you to send SMS through Skebby SMS Gateway.
@@ -12,13 +14,13 @@ Allows you to send SMS through Skebby SMS Gateway.
 
 Add this line to your application's Gemfile:
 
-    gem 'skuby'
+    gem 'skuby', github: 'k3rn31/skuby', branch: 'master'
 
 And then execute:
 
     $ bundle
 
-Or install it yourself as:
+Or install it yourself as (NOTE: this fork isn't present on rubygems.org):
 
     $ gem install skuby
 
@@ -40,8 +42,9 @@ Put these lines in `config/environments/production.rb` if you are using Skuby in
 ### Send SMS
 
 Use international phone numbers without +, e.g. (for Italy) `393290000000`
+NOTE: This fork of Skuby uses a hash and allows to send multiple recipients with associated variables.
 
-    sms = Skuby::Gateway.send_sms('Lorem ipsum', '393290000000')
+    sms = Skuby::Gateway.send_sms('Lorem ipsum', [{recipient: '393290000000', nome: 'Nome'}, {...}])
     sms.success? #=> true
 
 ### Credit

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Skuby
 
 [![Build Status](https://travis-ci.org/k3rn31/skuby.svg?branch=master)](https://travis-ci.org/k3rn31/skuby)
-<!--
-[![Coverage Status](https://coveralls.io/repos/welaika/skuby/badge.png)](https://coveralls.io/r/welaika/skuby)
-[![Code Climate](https://codeclimate.com/github/welaika/skuby.png)](https://codeclimate.com/github/welaika/skuby)
-[![Dependency Status](https://gemnasium.com/welaika/skuby.png)](https://gemnasium.com/welaika/skuby) -->
+[![Coverage Status](https://coveralls.io/repos/github/k3rn31/skuby/badge.svg)](https://coveralls.io/github/k3rn31/skuby)
+[![Code Climate](https://codeclimate.com/github/k3rn31/skuby/badges/gpa.svg)](https://codeclimate.com/github/k3rn31/skuby)
 
 NOTE: This is a fork of the original [Skuby](https://github.com/welaika/skuby) by Fabrizio Monti, Filippo Gangi Dino. This fork exists because I needed a specific behaviour from this gem. The main difference is in the recipient format.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Skuby
 
-<!-- [![Build Status](https://travis-ci.org/welaika/skuby.png?branch=master)](https://travis-ci.org/welaika/skuby)
+[![Build Status](https://travis-ci.org/k3rn31/skuby.svg?branch=master)](https://travis-ci.org/k3rn31/skuby)
+<!--
 [![Coverage Status](https://coveralls.io/repos/welaika/skuby/badge.png)](https://coveralls.io/r/welaika/skuby)
 [![Code Climate](https://codeclimate.com/github/welaika/skuby.png)](https://codeclimate.com/github/welaika/skuby)
 [![Dependency Status](https://gemnasium.com/welaika/skuby.png)](https://gemnasium.com/welaika/skuby) -->

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/k3rn31/skuby.svg?branch=master)](https://travis-ci.org/k3rn31/skuby)
 [![Coverage Status](https://coveralls.io/repos/github/k3rn31/skuby/badge.svg)](https://coveralls.io/github/k3rn31/skuby)
 [![Code Climate](https://codeclimate.com/github/k3rn31/skuby/badges/gpa.svg)](https://codeclimate.com/github/k3rn31/skuby)
+[![Dependency Status](https://gemnasium.com/badges/github.com/k3rn31/skuby.svg)](https://gemnasium.com/github.com/k3rn31/skuby)
 
 NOTE: This is a fork of the original [Skuby](https://github.com/welaika/skuby) by Fabrizio Monti, Filippo Gangi Dino. This fork exists because I needed a specific behaviour from this gem. The main difference is in the recipient format.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 desc 'Default: run specs'
 task default: :spec
 
 RSpec::Core::RakeTask.new do |t|
-  t.pattern = "spec/**/*_spec.rb"
+  t.pattern = 'spec/**/*_spec.rb'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,12 @@
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require 'rake/testtask'
 
-desc 'Default: run specs'
-task default: :spec
-
-RSpec::Core::RakeTask.new do |t|
-  t.pattern = 'spec/**/*_spec.rb'
+Rake::TestTask.new do |t|
+  t.libs << 'spec'
+  t.test_files = FileList['spec/**/*_spec.rb']
+  t.verbose = false
+  t.warning = false
 end
+desc 'Run tests'
+
+task default: :test

--- a/lib/skuby.rb
+++ b/lib/skuby.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'httparty'
 require 'cgi'
 require 'active_support/core_ext/object'

--- a/lib/skuby.rb
+++ b/lib/skuby.rb
@@ -8,14 +8,14 @@ require 'skuby/sms_response'
 require 'skuby/report'
 require 'skuby/credit'
 
+# Skuby is a Ruby interface for Skebby.
+# It allows you to send SMS through Skebby SMS Gateway.
 module Skuby
-
   def self.setup
-    yield self.config
+    yield config
   end
 
   def self.config
     @config ||= Configuration.new
   end
-
 end

--- a/lib/skuby/configuration.rb
+++ b/lib/skuby/configuration.rb
@@ -18,7 +18,7 @@ module Skuby
     end
 
     def to_hash
-      instance_variables.inject({}) do |result, var|
+      instance_variables.each_with_object({}) do |var, result|
         result[var.to_s.delete('@')] = instance_variable_get(var)
         result
       end

--- a/lib/skuby/configuration.rb
+++ b/lib/skuby/configuration.rb
@@ -1,14 +1,14 @@
 module Skuby
+  # This class sets un the configuration.
   class Configuration
-
-    SEND_METHODS = [
-      'send_sms_basic',
-      'send_sms_classic',
-      'send_sms_classic_report',
-      'test_send_sms_basic',
-      'test_send_sms_classic',
-      'test_send_sms_classic_report'
-    ]
+    SEND_METHODS = %w(
+      send_sms_basic
+      send_sms_clasic
+      send_sms_classi_report
+      test_send_sms_basic
+      test_send_sms_clasic
+      test_send_sms_classi_report
+    ).freeze
 
     attr_accessor :username, :password, :method,
                   :sender_number, :sender_string, :charset
@@ -19,10 +19,9 @@ module Skuby
 
     def to_hash
       instance_variables.inject({}) do |result, var|
-        result[var.to_s.delete("@")] = instance_variable_get(var)
+        result[var.to_s.delete('@')] = instance_variable_get(var)
         result
       end
     end
-
   end
 end

--- a/lib/skuby/configuration.rb
+++ b/lib/skuby/configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Skuby
   # This class sets un the configuration.
   class Configuration

--- a/lib/skuby/credit.rb
+++ b/lib/skuby/credit.rb
@@ -6,7 +6,7 @@ module Skuby
     base_uri 'https://gateway.skebby.it/api/send/smseasy/advanced/http.php'
 
     def self.balance
-      response = CGI.parse(post('', body: build_params))
+      response = CGI.parse(post('', body: build_params, verify: false))
       if response['status'].first == 'success'
         response['credit_left'].first.to_f
       end

--- a/lib/skuby/credit.rb
+++ b/lib/skuby/credit.rb
@@ -1,17 +1,18 @@
 module Skuby
+  # This class retrieves the current credit balance at Skebby.
   class Credit
     include HTTParty
     base_uri 'https://gateway.skebby.it/api/send/smseasy/advanced/http.php'
 
     def self.balance
       response = CGI.parse(post('', body: build_params))
-      response["credit_left"].first.to_f if response["status"].first == "success"
+      if response['status'].first == 'success'
+        response['credit_left'].first.to_f
+      end
     end
 
     def self.build_params
-      Skuby.config.to_hash.merge({'method' => 'get_credit'})
+      Skuby.config.to_hash.merge('method' => 'get_credit')
     end
-
   end
 end
-

--- a/lib/skuby/credit.rb
+++ b/lib/skuby/credit.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Skuby
   # This class retrieves the current credit balance at Skebby.
   class Credit

--- a/lib/skuby/gateway.rb
+++ b/lib/skuby/gateway.rb
@@ -1,13 +1,20 @@
 module Skuby
+  # This class in the main interface with Skebby. It talks with the base_uri
+  # to send an SMS.
   class Gateway
     include HTTParty
     base_uri 'https://gateway.skebby.it/api/send/smseasy/advanced/http.php'
 
+    # Sends the SMS.
+    # - text: the text of the SMS
+    # - recipients: and array of hashes containing numbers and variable:
+    #   [{recipient: '391234567', nome: 'Nome'}, {...}]
     def self.send_sms(text = '', recipients = '')
       params = build_params(text, recipients)
       SMSResponse.new(post('', body: params), text, recipients)
     end
 
+    # Builds the parameters for the http request to Skebby.
     def self.build_params(text, recipients)
       recipients_hash = {}
       recipients.each_with_index do |recipient, index|

--- a/lib/skuby/gateway.rb
+++ b/lib/skuby/gateway.rb
@@ -9,8 +9,14 @@ module Skuby
     end
 
     def self.build_params(text, recipients)
-      Skuby.config.to_hash.merge({'text' => text, 'recipients[]' => recipients})
+      recipients_hash = {}
+      recipients.each_with_index do |recipient, index|
+        recipient.each do |key, value|
+          recipients_hash["recipients[#{index}][#{key}]"] = value
+        end
+      end
+      recipients_hash['text'] = text
+      Skuby.config.to_hash.merge(recipients_hash)
     end
   end
 end
-

--- a/lib/skuby/gateway.rb
+++ b/lib/skuby/gateway.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Skuby
   # This class in the main interface with Skebby. It talks with the base_uri
   # to send an SMS.

--- a/lib/skuby/gateway.rb
+++ b/lib/skuby/gateway.rb
@@ -5,7 +5,7 @@ module Skuby
 
     def self.send_sms(text = '', recipients = '')
       params = build_params(text, recipients)
-      SMSResponse.new(self.post('', body: params), text, recipients)
+      SMSResponse.new(post('', body: params), text, recipients)
     end
 
     def self.build_params(text, recipients)

--- a/lib/skuby/gateway.rb
+++ b/lib/skuby/gateway.rb
@@ -12,7 +12,7 @@ module Skuby
     #   [{recipient: '391234567', nome: 'Nome'}, {...}]
     def self.send_sms(text = '', recipients = '')
       params = build_params(text, recipients)
-      SMSResponse.new(post('', body: params), text, recipients)
+      SMSResponse.new(post('', body: params, verify: false), text, recipients)
     end
 
     # Builds the parameters for the http request to Skebby.

--- a/lib/skuby/report.rb
+++ b/lib/skuby/report.rb
@@ -76,6 +76,10 @@ module Skuby
       Time.zone.parse(@raw['skebby_date_time'])
     end
 
+    def user_reference
+      @raw['user_reference']
+    end
+
     def recipient
       @raw['recipient']
     end

--- a/lib/skuby/report.rb
+++ b/lib/skuby/report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Skuby
   # This class parses the parameters sent by Skebby to update the SMS status.
   class Report

--- a/lib/skuby/report.rb
+++ b/lib/skuby/report.rb
@@ -61,7 +61,7 @@ module Skuby
     end
 
     def message_id
-      @raw['skebby_message_id'].to_i
+      @raw['skebby_message_id']
     end
 
     def dispatch_id

--- a/lib/skuby/report.rb
+++ b/lib/skuby/report.rb
@@ -1,21 +1,24 @@
 module Skuby
+  # This class parses the parameters sent by Skebby to update the SMS status.
   class Report
-
     STATUS_MAPPING = {
       'DELIVERED'     => 'Messaggio consegnato',
-      'EXPIRED'       => 'Messaggio scaduto (telefono spento/non raggiungibile)',
+      'EXPIRED'       => 'Messaggio scaduto (telefono spento/non' \
+                        ' raggiungibile)',
       'DELETED'       => 'Errore rete operatore',
-      'UNDELIVERABLE' => 'Messaggio non spedito (Vedi sotto variabile error_code)',
+      'UNDELIVERABLE' => 'Messaggio non spedito (Vedi sotto variabile' \
+                          ' error_code)',
       'UNKNOWN'       => 'Errore generico',
       'REJECTD'       => 'Messaggio rifiutato dall\'operatore'
-    }
+    }.freeze
 
     ERROR_CODES = {
       1   => 'Consegnato',
       401 => 'Messaggio scaduto (telefono spento/non raggiungibile)',
       201 => 'Malfunzionamento rete operatore',
       203 => 'Destinatario non raggiungibile (in roaming)',
-      301 => 'Destinatario non valido (inesistente/in portabilita\' - non abilitato)',
+      301 => 'Destinatario non valido (inesistente/in portabilita\'' \
+             ' - non abilitato)',
       302 => 'Numero errato',
       303 => 'Servizio SMS non abilitato',
       304 => 'Testo riconosciuto come spam',
@@ -32,7 +35,7 @@ module Skuby
       910 => 'Testo troppo lungo',
       101 => 'Malfunzionamento generico operatore',
       202 => 'Messaggio rifiutato dall\'operatore'
-    }
+    }.freeze
 
     attr_reader :raw
 
@@ -41,15 +44,15 @@ module Skuby
     end
 
     def success?
-      status == "DELIVERED"
+      status == 'DELIVERED'
     end
 
     def status
-      @raw["status"]
+      @raw['status']
     end
 
     def error_code
-      @raw["error_code"].to_i
+      @raw['error_code'].to_i
     end
 
     def error_message
@@ -57,23 +60,23 @@ module Skuby
     end
 
     def message_id
-      @raw["skebby_message_id"].to_i
+      @raw['skebby_message_id'].to_i
     end
 
     def dispatch_id
-      @raw["skebby_dispatch_id"]
+      @raw['skebby_dispatch_id']
     end
 
     def delivered_at
-      Time.zone.parse(@raw["operator_date_time"])
+      Time.zone.parse(@raw['operator_date_time'])
     end
 
     def skebby_at
-      Time.zone.parse(@raw["skebby_date_time"])
+      Time.zone.parse(@raw['skebby_date_time'])
     end
 
     def recipient
-      @raw["recipient"]
+      @raw['recipient']
     end
   end
 end

--- a/lib/skuby/report.rb
+++ b/lib/skuby/report.rb
@@ -65,8 +65,15 @@ module Skuby
     end
 
     def delivered_at
-      Time.parse(@raw["operator_date_time"])
+      Time.zone.parse(@raw["operator_date_time"])
     end
 
+    def skebby_at
+      Time.zone.parse(@raw["skebby_date_time"])
+    end
+
+    def recipient
+      @raw["recipient"]
+    end
   end
 end

--- a/lib/skuby/report.rb
+++ b/lib/skuby/report.rb
@@ -57,7 +57,7 @@ module Skuby
     end
 
     def message_id
-      @raw["skebby_message_id"]
+      @raw["skebby_message_id"].to_i
     end
 
     def dispatch_id

--- a/lib/skuby/sms_response.rb
+++ b/lib/skuby/sms_response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Skuby
   # This class gets the response from Skebby.
   class SMSResponse

--- a/lib/skuby/sms_response.rb
+++ b/lib/skuby/sms_response.rb
@@ -1,4 +1,5 @@
 module Skuby
+  # This class gets the response from Skebby.
   class SMSResponse
     attr_reader :response, :text, :recipients
 
@@ -9,7 +10,7 @@ module Skuby
     end
 
     def success?
-      status == "success"
+      status == 'success'
     end
 
     def sms_id?
@@ -17,25 +18,23 @@ module Skuby
     end
 
     def status
-      @response["status"].first
+      @response['status'].first
     end
 
     def remaining_sms
-      @response["remaining_sms"].first.to_i
+      @response['remaining_sms'].first.to_i
     end
 
     def sms_id
-      @response["id"].first
+      @response['id'].first
     end
 
     def error_code
-      @response["code"].first.to_i
+      @response['code'].first.to_i
     end
 
     def error_message
-      @response["message"].first
+      @response['message'].first
     end
-
   end
 end
-

--- a/lib/skuby/version.rb
+++ b/lib/skuby/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Skuby
-  VERSION = '0.0.6'.freeze
+  VERSION = '0.0.6'
 end

--- a/lib/skuby/version.rb
+++ b/lib/skuby/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Skuby
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end

--- a/lib/skuby/version.rb
+++ b/lib/skuby/version.rb
@@ -1,3 +1,3 @@
 module Skuby
-  VERSION = "0.0.5"
+  VERSION = '0.0.5'.freeze
 end

--- a/lib/skuby/version.rb
+++ b/lib/skuby/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Skuby
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end

--- a/lib/skuby/version.rb
+++ b/lib/skuby/version.rb
@@ -1,3 +1,3 @@
 module Skuby
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.6'.freeze
 end

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -4,29 +4,30 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'skuby/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "skuby"
+  spec.name          = 'skuby'
   spec.version       = Skuby::VERSION
-  spec.authors       = ["Fabrizio Monti", "Filippo Gangi Dino"]
-  spec.email         = ["fabrizio.monti@welaika.com", "filippo.gangidino@welaika.com"]
-  spec.description   = %q{A Ruby interface to Skebby}
-  spec.summary       = %q{Allows you to send SMS through Skebby SMS Gateway}
-  spec.homepage      = "https://github.com/welaika/skuby"
-  spec.license       = "MIT"
+  spec.authors       = ['Fabrizio Monti', 'Filippo Gangi Dino']
+  spec.email         = ['fabrizio.monti@welaika.com',
+                        'filippo.gangidino@welaika.com']
+  spec.description   = %(A Ruby interface to Skebby)
+  spec.summary       = %(Allows you to send SMS through Skebby SMS Gateway)
+  spec.homepage      = 'https://github.com/welaika/skuby'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($RS)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "httparty"
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency 'httparty'
+  spec.add_runtime_dependency 'activesupport'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "pry-plus"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "mocha"
-  spec.add_development_dependency "webmock"
-  spec.add_development_dependency "vcr"
-  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'pry-plus'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'mocha'
+  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'coveralls'
 end

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'minitest/reporters'
+  spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'
 end

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = %(A Ruby interface to Skebby)
   spec.summary       = %(Allows you to send SMS through Skebby SMS Gateway)
   spec.homepage      = 'https://github.com/l3rn31/skuby'
-  spec.license       = ['MIT']
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($RS)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -6,7 +6,9 @@ require 'skuby/version'
 Gem::Specification.new do |spec|
   spec.name          = 'skuby'
   spec.version       = Skuby::VERSION
-  spec.authors       = ['Fabrizio Monti', 'Filippo Gangi Dino', 'Davide Petilli']
+  spec.authors       = ['Fabrizio Monti',
+                        'Filippo Gangi Dino',
+                        'Davide Petilli']
   spec.email         = ['fabrizio.monti@welaika.com',
                         'filippo.gangidino@welaika.com']
   spec.description   = %(A Ruby interface to Skebby)
@@ -24,6 +26,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest/reporters'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'
 end

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -6,13 +6,13 @@ require 'skuby/version'
 Gem::Specification.new do |spec|
   spec.name          = 'skuby'
   spec.version       = Skuby::VERSION
-  spec.authors       = ['Fabrizio Monti', 'Filippo Gangi Dino']
+  spec.authors       = ['Fabrizio Monti', 'Filippo Gangi Dino', 'Davide Petilli']
   spec.email         = ['fabrizio.monti@welaika.com',
                         'filippo.gangidino@welaika.com']
   spec.description   = %(A Ruby interface to Skebby)
   spec.summary       = %(Allows you to send SMS through Skebby SMS Gateway)
-  spec.homepage      = 'https://github.com/welaika/skuby'
-  spec.license       = 'MIT'
+  spec.homepage      = 'https://github.com/l3rn31/skuby'
+  spec.license       = ['MIT']
 
   spec.files         = `git ls-files`.split($RS)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -24,8 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'
 end

--- a/skuby.gemspec
+++ b/skuby.gemspec
@@ -23,11 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'pry-plus'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'coveralls'
 end

--- a/spec/credit_spec.rb
+++ b/spec/credit_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Skuby::Credit do

--- a/spec/credit_spec.rb
+++ b/spec/credit_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Skuby::Credit do
-
   before do
     Skuby.setup do |config|
       config.username = 'username'
@@ -10,24 +9,20 @@ describe Skuby::Credit do
     end
   end
 
-  context "::balance" do
-    it "returns balance in euro" do
-      VCR.use_cassette('get_credit') do
-        request = Skuby::Credit.balance
-        expect(request).to eq(9.49)
-      end
+  it 'returns balance in euro' do
+    VCR.use_cassette('get_credit') do
+      request = Skuby::Credit.balance
+      request.must_equal 9.49
     end
+  end
 
-    context "with wrong credentials" do
-      before { Skuby.setup do |config| config.password = 'wrong_password' end }
-
-      it "returns nil if something's wrong" do
-        VCR.use_cassette('get_credit_wrong_credentials') do
-          expect(Skuby::Credit.balance).to be_nil
-        end
-      end
-
+  it 'returns nil if smomething is wrong' do
+    Skuby.setup do |config|
+      config.password = 'wrong_password'
+    end
+    VCR.use_cassette('get_credit_wrong_credentials') do
+      request = Skuby::Credit.balance
+      request.must_be_nil
     end
   end
 end
-

--- a/spec/fixtures/vcr_cassettes/send_sms_basic.yml
+++ b/spec/fixtures/vcr_cassettes/send_sms_basic.yml
@@ -5,26 +5,32 @@ http_interactions:
     uri: https://gateway.skebby.it/api/send/smseasy/advanced/http.php
     body:
       encoding: UTF-8
-      string: method=send_sms_basic&username=username&password=password&sender_string=company&text=Lorem%20ipsum&recipients[]=393290000000
-    headers: {}
+      string: method=send_sms_basic&username=username&password=password&sender_string=company&recipients[0][recipient]=393290000000&text=Lorem%20ipsum
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2013 10:52:45 GMT
+      - Fri, 19 Aug 2016 14:14:47 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '32'
+      - '129'
       Content-Type:
       - text/html
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: status=success&remaining_sms=207
-    http_version: 
-  recorded_at: Mon, 11 Nov 2013 10:52:45 GMT
-recorded_with: VCR 2.7.0
+    http_version:
+  recorded_at: Fri, 19 Aug 2016 14:14:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/send_sms_classic.yml
+++ b/spec/fixtures/vcr_cassettes/send_sms_classic.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://gateway.skebby.it/api/send/smseasy/advanced/http.php
     body:
       encoding: UTF-8
-      string: method=send_sms_classic&username=username&password=password&sender_string=company&text=Lorem%20ipsum&recipients[]=393290000000
+      string: method=send_sms_classic&username=username&password=password&sender_string=company&recipients[0][recipient]=393290000000&text=Lorem%20ipsum
     headers: {}
   response:
     status:
@@ -25,6 +25,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: status=success&remaining_sms=152
-    http_version: 
+    http_version:
   recorded_at: Mon, 11 Nov 2013 10:50:00 GMT
 recorded_with: VCR 2.7.0

--- a/spec/fixtures/vcr_cassettes/send_sms_no_recipient.yml
+++ b/spec/fixtures/vcr_cassettes/send_sms_no_recipient.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://gateway.skebby.it/api/send/smseasy/advanced/http.php
     body:
       encoding: UTF-8
-      string: method=send_sms_classic_report&username=username&password=password&sender_string=company&text=Lorem%20ipsum&recipients[]=
+      string: method=send_sms_classic_report&username=username&password=password&sender_string=company&text=Lorem%20ipsum
     headers: {}
   response:
     status:
@@ -25,6 +25,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: status=failed&code=25&message=Recipient+not+valid+%28must+be+in+international+format+like+393401234567%29
-    http_version: 
+    http_version:
   recorded_at: Mon, 11 Nov 2013 10:48:22 GMT
 recorded_with: VCR 2.7.0

--- a/spec/fixtures/vcr_cassettes/send_sms_wrong_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/send_sms_wrong_credentials.yml
@@ -5,26 +5,32 @@ http_interactions:
     uri: https://gateway.skebby.it/api/send/smseasy/advanced/http.php
     body:
       encoding: UTF-8
-      string: method=send_sms_classic_report&username=username&password=wrong_password&sender_string=company&text=Lorem%20ipsum&recipients[]=393290000000
-    headers: {}
+      string: method=send_sms_basic&username=username&password=wrong_password&sender_string=company&recipients[0][recipient]=393290000000&text=Lorem%20ipsum
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2013 10:56:48 GMT
+      - Fri, 19 Aug 2016 14:16:12 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '144'
+      - '129'
       Content-Type:
       - text/html
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: status=failed&code=21&message=Username+or+password+not+valid%2C+you+cannot+use+your+email+or+phone+number%2C+only+username+is+allowed+on+gateway
-    http_version: 
-  recorded_at: Mon, 11 Nov 2013 10:56:48 GMT
-recorded_with: VCR 2.7.0
+    http_version:
+  recorded_at: Fri, 19 Aug 2016 14:16:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Skuby::Gateway do
-
   before do
     Skuby.setup do |config|
       config.username = 'username'
@@ -10,83 +9,80 @@ describe Skuby::Gateway do
     end
   end
 
-  context "with send sms classic" do
-    before { Skuby.setup do |config| config.method = 'send_sms_classic' end }
+  it 'should send sms classic' do
+    Skuby.setup do |config|
+      config.method = 'send_sms_classic'
+    end
 
-    it "successfully send an sms" do
-      VCR.use_cassette('send_sms_classic') do
-        response = Skuby::Gateway.send_sms('Lorem ipsum', '393290000000')
-        expect(response.success?).to be_true
-        expect(response.sms_id?).to be_false
-        expect(response.remaining_sms).to eq(152)
-        expect(response.text).to eq('Lorem ipsum')
-        expect(response.recipients).to eq(['393290000000'])
-      end
+    VCR.use_cassette('send_sms_classic') do
+      response = Skuby::Gateway.send_sms(
+        'Lorem ipsum', [{ recipient: '393290000000' }]
+      )
+      response.success?.must_equal true
+      response.sms_id?.wont_equal true
+      response.remaining_sms.must_equal 152
+      response.text.must_equal 'Lorem ipsum'
+      response.recipients.must_equal [{ recipient: '393290000000' }]
     end
   end
 
-  context "with send sms basic" do
-    before { Skuby.setup do |config| config.method = 'send_sms_basic' end }
+  it 'should send sms basic' do
+    Skuby.setup do |config|
+      config.method = 'send_sms_basic'
+    end
 
-    it "successfully send an sms" do
-      VCR.use_cassette('send_sms_basic') do
-        response = Skuby::Gateway.send_sms('Lorem ipsum', '393290000000')
-        expect(response.success?).to be_true
-        expect(response.sms_id?).to be_false
-        expect(response.remaining_sms).to eq(207)
-        expect(response.text).to eq('Lorem ipsum')
-        expect(response.recipients).to eq(['393290000000'])
-      end
+    VCR.use_cassette('send_sms_basic') do
+      response = Skuby::Gateway.send_sms('Lorem ipsum',
+                                         [{ recipient: '393290000000' }])
+      response.success?.must_equal true
+      response.sms_id?.wont_equal true
+      response.remaining_sms.must_equal 207
+      response.text.must_equal 'Lorem ipsum'
+      response.recipients.must_equal [{ recipient: '393290000000' }]
     end
   end
 
-  context "with send sms classic report" do
-    before { Skuby.setup do |config| config.method = 'send_sms_classic_report' end }
-
-    it "successfully send an sms" do
-      VCR.use_cassette('send_sms_classic_report') do
-        response = Skuby::Gateway.send_sms('Lorem ipsum', '393290000000')
-        expect(response.success?).to be_true
-        expect(response.sms_id?).to be_true
-        expect(response.sms_id).to eq('64608933')
-        expect(response.remaining_sms).to eq(150)
-        expect(response.text).to eq('Lorem ipsum')
-        expect(response.recipients).to eq(['393290000000'])
-      end
+  it 'should send sms classic+' do
+    Skuby.setup do |config|
+      config.method = 'send_sms_basic'
+    end
+    VCR.use_cassette('send_sms_basic') do
+      response = Skuby::Gateway.send_sms('Lorem ipsum',
+                                         [{ recipient: '393290000000' }])
+      response.success?.must_equal true
+      response.sms_id?.wont_equal true
+      response.remaining_sms.must_equal 207
+      response.text.must_equal 'Lorem ipsum'
+      response.recipients.must_equal [{ recipient: '393290000000' }]
     end
   end
 
-  context "with errors in request" do
-    before { Skuby.setup do |config| config.method = 'send_sms_classic_report' end }
-
-    context "no recipient" do
-      it "returns an error" do
-        VCR.use_cassette('send_sms_no_recipient') do
-          response = Skuby::Gateway.send_sms('Lorem ipsum')
-          expect(response.success?).to be_false
-          expect(response.error_code).to eq(25)
-          expect(response.error_message).to be_present
-          expect(response.text).to eq('Lorem ipsum')
-          expect(response.recipients).to eq([""])
-        end
-      end
+  it 'returns an error with no sender' do
+    Skuby.setup do |config|
+      config.method = 'send_sms_classic_report'
     end
-
-    context "with wrong credentials" do
-      before { Skuby.setup do |config| config.password = 'wrong_password' end }
-
-      it "returns an error" do
-        VCR.use_cassette('send_sms_wrong_credentials') do
-          response = Skuby::Gateway.send_sms('Lorem ipsum', '393290000000')
-          expect(response.success?).to be_false
-          expect(response.error_code).to eq(21)
-          expect(response.error_message).to be_present
-          expect(response.text).to eq('Lorem ipsum')
-          expect(response.recipients).to eq(['393290000000'])
-        end
-      end
+    VCR.use_cassette('send_sms_no_recipient') do
+      response = Skuby::Gateway.send_sms('Lorem ipsum', [])
+      response.success?.must_equal false
+      response.error_code.must_equal 25
+      response.error_message.wont_be_empty
+      response.text.must_equal 'Lorem ipsum'
+      response.recipients.must_equal []
     end
+  end
 
+  it 'returns an error with wrong credentials' do
+    Skuby.setup do |config|
+      config.password = 'wrong_password'
+    end
+    VCR.use_cassette('send_sms_wrong_credentials') do
+      response = Skuby::Gateway.send_sms('Lorem ipsum',
+                                         [{ recipient: '393290000000' }])
+      response.success?.must_equal false
+      response.error_code.must_equal 21
+      response.error_message.wont_be_empty
+      response.text.must_equal 'Lorem ipsum'
+      response.recipients.must_equal [{ recipient: '393290000000' }]
+    end
   end
 end
-

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Skuby::Gateway do

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -45,6 +45,7 @@ describe Skuby::Report do
     report.success?.must_equal true
     report.message_id.must_equal 777
     report.dispatch_id.must_equal '666'
+    report.recipient.must_equal '393471234567'
     report.delivered_at.must_equal Time.new(
       2012, 2, 19, 17, 51, 1, '+00:00'
     ).in_time_zone

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -46,6 +46,7 @@ describe Skuby::Report do
     report.message_id.must_equal 777
     report.dispatch_id.must_equal '666'
     report.recipient.must_equal '393471234567'
+    report.user_reference.must_equal '12345'
     report.delivered_at.must_equal Time.new(
       2012, 2, 19, 17, 51, 1, '+00:00'
     ).in_time_zone

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1,36 +1,55 @@
 require 'spec_helper'
-require 'yaml'
 
 describe Skuby::Report do
-  let(:report) { Skuby::Report.new(params) }
-
-  context "with errors" do
-    let(:params) { YAML.load(File.open(fixture_for_skebby_report('error.yaml'))) }
-
-    it "parses skebby response" do
-      expect(report.success?).to be_false
-      expect(report.error_code).to eq(502)
-      expect(report.error_message).to be_present
-      expect(report.message_id).to eq('333')
-      expect(report.dispatch_id).to eq('444')
-      expect(report.delivered_at).to eq(Time.new(2005,8,15,15,51,1,"+00:00"))
+  before do
+    Skuby.setup do |config|
+      config.username = 'username'
+      config.password = 'password'
+      config.sender_string = 'company'
     end
+    Time.zone = 'Europe/Rome'
   end
 
-  context "without errors" do
-    let(:params) { YAML.load(File.open(fixture_for_skebby_report('delivered.yaml'))) }
+  it 'should parses skebby response with errors' do
+    params =
+      YAML.load(
+        File.open(
+          fixture_for_skebby_report('error.yaml')
+        )
+      )
+    report = Skuby::Report.new(params)
 
-    it "parses skebby response" do
-      expect(report.success?).to be_true
-      expect(report.message_id).to eq('777')
-      expect(report.dispatch_id).to eq('666')
-      expect(report.delivered_at).to eq(Time.new(2012,2,19,17,51,1,"+00:00"))
-    end
+    report.success?.must_equal false
+    report.error_code.must_equal 502
+    report.error_message.wont_be_empty
+    report.message_id.must_equal 333
+    report.dispatch_id.must_equal '444'
+    report.delivered_at.must_equal Time.new(
+      2005, 8, 15, 15, 51, 1, '+00:00'
+    ).in_time_zone
+    report.skebby_at.must_equal Time.new(
+      2005, 8, 15, 15, 52, 1, '+00:00'
+    ).in_time_zone
+  end
+
+  it 'should parses skebby response with errors' do
+    params =
+      YAML.load(
+        File.open(
+          fixture_for_skebby_report('delivered.yaml')
+        )
+      )
+    report = Skuby::Report.new(params)
+
+    report.success?.must_equal true
+    report.message_id.must_equal 777
+    report.dispatch_id.must_equal '666'
+    report.delivered_at.must_equal Time.new(
+      2012, 2, 19, 17, 51, 1, '+00:00'
+    ).in_time_zone
   end
 
   def fixture_for_skebby_report(name)
     File.join(File.dirname(__FILE__), 'fixtures', 'skebby_report', name)
   end
-
 end
-

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -23,7 +23,7 @@ describe Skuby::Report do
     report.success?.must_equal false
     report.error_code.must_equal 502
     report.error_message.wont_be_empty
-    report.message_id.must_equal 333
+    report.message_id.must_equal '333'
     report.dispatch_id.must_equal '444'
     report.delivered_at.must_equal Time.new(
       2005, 8, 15, 15, 51, 1, '+00:00'
@@ -43,7 +43,7 @@ describe Skuby::Report do
     report = Skuby::Report.new(params)
 
     report.success?.must_equal true
-    report.message_id.must_equal 777
+    report.message_id.must_equal '777'
     report.dispatch_id.must_equal '666'
     report.recipient.must_equal '393471234567'
     report.user_reference.must_equal '12345'

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Skuby::Report do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,14 @@ require 'minitest/autorun'
 require 'webmock/minitest'
 require 'vcr'
 require 'coveralls'
+require 'simplecov'
 
 require_relative '../lib/skuby'
 
-Coveralls.wear!
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'spec'
+end
 Minitest::Reporters.use!
 
 VCR.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/reporters'
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,27 +1,15 @@
-require 'coveralls'
-Coveralls.wear!
-
-require 'webmock/rspec'
-require 'mocha/api'
+require 'minitest/reporters'
+require 'minitest/autorun'
+require 'webmock/minitest'
 require 'vcr'
-require 'pry'
+require_relative '../lib/skuby'
 
-require 'skuby'
+Minitest::Reporters.use!
 
-RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.run_all_when_everything_filtered = true
-  config.filter_run :focus
-  config.mock_framework = :mocha
-  config.order = 'random'
+VCR.configure do |config|
+  config.default_cassette_options = {
+    match_requests_on: [:method, :uri]
+  }
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.hook_into :webmock
 end
-
-VCR.configure do |c|
-  c.default_cassette_options = { match_requests_on: [:method, :uri, :body] }
-  c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
-  c.hook_into :webmock
-end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,11 @@ require 'minitest/reporters'
 require 'minitest/autorun'
 require 'webmock/minitest'
 require 'vcr'
+require 'coveralls'
+
 require_relative '../lib/skuby'
 
+Coveralls.wear!
 Minitest::Reporters.use!
 
 VCR.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,16 @@
 # frozen_string_literal: true
+require 'coveralls'
+require 'simplecov'
+
+SimpleCov.formatters = [
+  Coveralls::SimpleCov::Formatter,
+  SimpleCov::Formatter::HTMLFormatter
+]
+SimpleCov.start do
+  add_filter '/spec/'
+  command_name 'test:minitest'
+end
+
 require 'minitest/reporters'
 require 'minitest/autorun'
 require 'webmock/minitest'
@@ -8,10 +20,6 @@ require 'simplecov'
 
 require_relative '../lib/skuby'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-  add_filter 'spec'
-end
 Minitest::Reporters.use!
 
 VCR.configure do |config|


### PR DESCRIPTION
I changed the build_params method to accept recipients in the format accepted by Skebby to send multiple SMS with varialbles. I also added a couple of methods.
